### PR TITLE
Add encryptAsync and decryptAsync methods.

### DIFF
--- a/lib/krypt.js
+++ b/lib/krypt.js
@@ -150,3 +150,123 @@ Krypt.prototype.decrypt = function decrypt(input, secret) {
   }
 
 };
+
+
+Krypt.prototype.encryptAsync = function encryptAsync(input, secret, cb) {
+
+  if (!input) {
+    cb(new Error('You must provide a value to encrypt'));
+    return;
+  }
+
+  secret = secret || this.defaultSecret;
+  if (!secret) {
+    cb(new Error('A \'secret\' is required to encrypt'));
+    return;
+  }
+
+  // Legacy check to deal with old versions that recorded key length in Bytes
+  if (this.keyLength === 32) {
+    this.keyLength = this.keyLength * 8;
+  }
+
+  var salt = crypto.randomBytes(this.keyLength / 8),
+      iv = crypto.randomBytes(16);
+
+  crypto.pbkdf2(secret, salt, this.iterations, this.keyLength / 8, function(err, key) {
+    if (err) {
+      cb(new Error('Unable to encrypt value due to: ' + err));
+      return;
+    }
+
+    try {
+      var cipher = crypto.createCipheriv(CIPHER, key, iv);
+
+      var encryptedValue = cipher.update(input, 'utf8', 'base64');
+      encryptedValue += cipher.final('base64');
+
+      var result = {
+        cipher: CIPHER,
+        keyDerivation: KEY_DERIVATION,
+        keyLength: this.keyLength,
+        iterations: this.iterations,
+        iv: iv.toString('base64'),
+        salt: salt.toString('base64'),
+        value: encryptedValue
+      };
+
+      _.defaults(result, this.context);
+
+      cb(null, result);
+
+    } catch (err) {
+      cb(new Error('Unable to encrypt value due to: ' + err));
+    }
+  });
+
+};
+
+
+Krypt.prototype.decryptAsync = function decrypt(input, secret, cb) {
+
+  // Ensure we have something to decrypt
+  if (!input) {
+    cb(new Error('You must provide a value to decrypt'));
+    return;
+  }
+
+  // Ensure we have the secret used to encrypt this value
+  secret = secret || this.defaultSecret;
+  if (!secret) {
+    cb(new Error('A \'secret\' is required to decrypt'));
+    return;
+  }
+
+  // If we get a string as input, turn it into an object
+  if (typeof input !== 'object') {
+    try {
+      input = JSON.parse(input);
+    } catch (err) {
+      cb(new Error('Unable to parse string input as JSON'));
+      return;
+    }
+  }
+
+  // Ensure our input is a valid object with 'iv', 'salt', and 'value'
+  if (!input.iv || !input.salt || !input.value) {
+    cb(new Error('Input must be a valid object with \'iv\', \'salt\', and \'value\' properties'));
+    return;
+  }
+
+  var salt = new Buffer(input.salt, 'base64'),
+      iv = new Buffer(input.iv, 'base64'),
+      keyLength = input.keyLength || this.keyLength,
+      iterations = input.iterations || this.iterations;
+
+  // Legacy check to deal with old versions that recorded key length in Bytes
+  if (keyLength === 32) {
+    keyLength = keyLength * 8;
+  }
+
+  crypto.pbkdf2(secret, salt, iterations, keyLength / 8, function(err, key) {
+    if (err) {
+      cb(new Error('Unable to decrypt value due to: ' + err));
+      return;
+    }
+
+    try {
+
+      var decipher = crypto.createDecipheriv(CIPHER, key, iv);
+
+      var decryptedValue = decipher.update(input.value, 'base64', 'utf8');
+      decryptedValue += decipher.final('utf8');
+
+      cb(null, decryptedValue);
+
+    } catch (err) {
+      cb(new Error('Unable to decrypt value due to: ' + err));
+      return;
+    }
+  });
+
+};

--- a/test/krypt.js
+++ b/test/krypt.js
@@ -7,33 +7,77 @@ var PLAIN_TEXT = 'This is my text!',
 
 describe('Krypt', function () {
 
-  it('should successfuly encrypt a value', function (done) {
+  describe('synchronous functions', function () {
 
-    var encrypted = krypt.encrypt(PLAIN_TEXT, SECRET);
-    expect(encrypted).to.have.property('iv');
-    expect(encrypted).to.have.property('salt');
-    expect(encrypted).to.have.property('value');
-    done();
+    it('should successfuly encrypt a value', function (done) {
+
+      var encrypted = krypt.encrypt(PLAIN_TEXT, SECRET);
+      expect(encrypted).to.have.property('iv');
+      expect(encrypted).to.have.property('salt');
+      expect(encrypted).to.have.property('value');
+      done();
+
+    });
+
+    it('should successfuly decrypt a JSON value', function (done) {
+
+      var encrypted = krypt.encrypt(PLAIN_TEXT, SECRET),
+          decrypted = krypt.decrypt(encrypted, SECRET);
+
+      expect(decrypted).to.deep.equal(PLAIN_TEXT);
+      done();
+
+    });
+
+    it('should successfuly decrypt a string value', function (done) {
+
+      var encrypted = krypt.encrypt(PLAIN_TEXT, SECRET),
+          decrypted = krypt.decrypt(JSON.stringify(encrypted), SECRET);
+
+      expect(decrypted).to.deep.equal(PLAIN_TEXT);
+      done();
+
+    });
 
   });
 
-  it('should successfuly decrypt a JSON value', function (done) {
+  describe('asynchronous functions', function () {
 
-    var encrypted = krypt.encrypt(PLAIN_TEXT, SECRET),
-        decrypted = krypt.decrypt(encrypted, SECRET);
+    it('should successfuly encrypt a value', function (done) {
 
-    expect(decrypted).to.deep.equal(PLAIN_TEXT);
-    done();
+      krypt.encryptAsync(PLAIN_TEXT, SECRET, function(err, encrypted) {
+        expect(err).to.be.null;
+        expect(encrypted).to.have.property('iv');
+        expect(encrypted).to.have.property('salt');
+        expect(encrypted).to.have.property('value');
+        done();
+      });
 
-  });
+    });
 
-  it('should successfuly decrypt a string value', function (done) {
+    it('should successfuly decrypt a JSON value', function (done) {
 
-    var encrypted = krypt.encrypt(PLAIN_TEXT, SECRET),
-        decrypted = krypt.decrypt(JSON.stringify(encrypted), SECRET);
+      var encrypted = krypt.encrypt(PLAIN_TEXT, SECRET);
 
-    expect(decrypted).to.deep.equal(PLAIN_TEXT);
-    done();
+      krypt.decryptAsync(encrypted, SECRET, function(err, decrypted) {
+        expect(err).to.be.null;
+        expect(decrypted).to.deep.equal(PLAIN_TEXT);
+        done();
+      });
+
+    });
+
+    it('should successfuly decrypt a string value', function (done) {
+
+      var encrypted = krypt.encrypt(PLAIN_TEXT, SECRET);
+
+      krypt.decryptAsync(JSON.stringify(encrypted), SECRET, function(err, decrypted) {
+        expect(err).to.be.null;
+        expect(decrypted).to.deep.equal(PLAIN_TEXT);
+        done();
+      });
+
+    });
 
   });
 


### PR DESCRIPTION
Using the synchronous methods can starve the event loop.  By making the key stretching happen asynchronously, this can better handle multiple simultaneous requests.